### PR TITLE
Fix: there's no English for Exams dataset, so switched default sampe_case language to Vietnamese

### DIFF
--- a/bittranslate/prompt_dataset/exams.py
+++ b/bittranslate/prompt_dataset/exams.py
@@ -33,7 +33,7 @@ class Exams(PromptDataset):
             for shorthand, language in LANGUAGE_SHORTHANDS.items()
         }
 
-    def sample_case(self, language="en") -> str:
+    def sample_case(self, language="vi") -> str:
         if language not in self._lang_datasets:
             raise ValueError(
                 f"{language} is an invalid language. "


### PR DESCRIPTION
## What's wrong?

- There's no English shorthand in the Exams dataset. But the default case for sample_case in Exams dataset points to `"en"`.

## What changed?

- Switched `"en"` to `"vi"` (Vietnamese) instead. Feel free to suggest other languages.